### PR TITLE
Fix/double color

### DIFF
--- a/Sources/SPConfetti/SPConfettiView.swift
+++ b/Sources/SPConfetti/SPConfettiView.swift
@@ -239,7 +239,6 @@ open class SPConfettiView: UIView {
         var image = particle.image.resize(newWidth: particleWidth)
         if particlesConfig.colored {
             image = image.colored(color)
-            cell.color = color.cgColor
         }
         cell.contents = image.cgImage
         


### PR DESCRIPTION
## Goal
Fixing a problem where colors were applied twice, making it slightly off from the expected color.
As the UIImages are already colored by the `UIImage.colored` function, there is no need to also apply the same color to the `CAEmitterCell`. Doing this applies the same color twice.

This removes the color from the emitter cell, although another solution could be painting the `UIImage` white and applying the correct color to the `CAEmitterCell`.

## Screenshot
**Before** and **After** screenshots of this change. As shown the pastel colors are slightly darker on the confetti than the colors shown in the view. They use the exact same color, but because of the double appliance, they turn out darker.

<div>
<img src="https://github.com/ivanvorobei/SPConfetti/assets/140403755/20827350-8f9a-4845-92cd-19673918f4a2" width=40% height=40%>

<img src="https://github.com/ivanvorobei/SPConfetti/assets/140403755/321c25f7-193e-4e77-a3ff-772741d8d8f0" width=40% height=40%>
</div>


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Testing in compability platforms
- [ ] Installed correct via `Swift Package Manager` and `Cocoapods`
